### PR TITLE
Improve README / Don't print usage errors when using -h/--help 

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,22 +86,23 @@
      
      > docker run -p 8080:8080 -it --rm mgmtapi-4_0 
      
+     > curl http://localhost:8080/api/v0/probes/liveness
+     OK
+     
      # Check service and C* are running
      > curl http://localhost:8080/api/v0/probes/readiness
      OK
      
-     > curl http://localhost:8080/api/v0/probes/liveness
-     OK
   
   To start the service with a locally installed C* you would run the following:
     
     # REQUIRED: Add management api agent to C* startup
     > export JVM_EXTRA_OPTS="-javaagent:$PWD/management-api-agent/target/datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar"
         
-    > alias mgmiapi="java -jar management-api-server/target/datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar"
+    > alias mgmtapi="java -jar management-api-server/target/datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar"
     
     # Start the service with a local unix socket only, you could also pass -H http://localhost:8080 to expose a port
-    > nohup mgmtapi --cassandra-socket=/tmp/cassandra.sock --host=unix:///tmp/mgmtapi.sock &
+    > mgmtapi --cassandra-socket=/tmp/cassandra.sock --host=unix:///tmp/mgmtapi.sock --cassandra-home=<pathToCassandra>
     
     # Cassandra will be started by the service by default unless you pass --explicit-start flag
     
@@ -121,8 +122,6 @@
   The cli help covers the different options:
     
     mgmtapi --help
-    
-    Usage error: Required option '-S' is missing
     
     NAME
             cassandra-management-api - REST service for managing an Apache

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/Cli.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/Cli.java
@@ -522,8 +522,18 @@ public class Cli implements Runnable
         }
         catch (ParseException p)
         {
-            System.err.println(String.format("Usage error: %s", p.getMessage()));
-            System.err.println();
+            //noinspection StatementWithEmptyBody
+            if (args.length > 0 && (args[0].equals("-h") || args[0].equals("--help")))
+            {
+                // don't tell the user it's a usage error
+                // a bug in airline (https://github.com/airlift/airline/issues/44) prints a usage error even if
+                // a user just uses -h/--help
+            }
+            else
+            {
+                System.err.println(String.format("Usage error: %s", p.getMessage()));
+                System.err.println();
+            }
 
             try
             {


### PR DESCRIPTION
Currently when you do `mgmtapi --help` you'll also see a usage error, because a required option wasn't provided:

```
mgmtapi --help

    Usage error: Required option '-S' is missing

    NAME
            cassandra-management-api - REST service for managing an Apache
            Cassandra node
```

This is unfortunately due to a bug in airline itself (airlift/airline#44). So it's easier to just have a workaround in place when printing the help message.