### PR TITLE
Release jars via github actions

### DIFF
--- a/.github/workflows/jar-release.yaml
+++ b/.github/workflows/jar-release.yaml
@@ -45,7 +45,9 @@ jobs:
         run: ls
       - name: Build with Maven
         run: mvn -q -ff package -DskipTests
-
+      - name: zip-up
+        run: |
+          zip jars.zip management-api-agent/target/datastax-mgmtapi-agent-*.jar management-api-server/target/datastax-mgmtapi-server-*.jar management-api-shim-4.x/target/datastax-mgmtapi-shim-4.x-*-SNAPSHOT.jar management-api-shim-3.x/target/datastax-mgmtapi-shim-3.x-*.jar management-api-common/target/datastax-mgmtapi-common-*.jar
       - name: Retrieve stashed release URL
         uses: actions/download-artifact@v1
         with:
@@ -54,53 +56,12 @@ jobs:
         id: get_release_url
         run: echo ::set-output name=URL::$(cat release-url/url.txt)
 
-      - name: Upload Agent
+      - name: Upload jars 
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.get_release_url.outputs.URL }}
-          asset_path: management-api-agent/target/datastax-mgmtapi-agent-*.jar
-          asset_name: datastax-mgmtapi-agent.jar
-          asset_content_type: text/html
-
-      - name: Upload API Server
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.get_release_url.outputs.URL }}
-          asset_path: management-api-server/target/datastax-mgmtapi-server-*.jar
-          asset_name: datastax-api-server.jar
-          asset_content_type: text/html
-
-      - name: Upload 4.x Shim 
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.get_release_url.outputs.URL }}
-          asset_path: management-api-shim-4.x/target/datastax-mgmtapi-shim-4.x-*-SNAPSHOT.jar
-          asset_name: datastax-mgmtapi-shim-4.x.jar
-          asset_content_type: text/html
-
-      - name: Upload 3.x Shim
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.get_release_url.outputs.URL }}
-          asset_path: management-api-shim-3.x/target/datastax-mgmtapi-shim-3.x-*.jar
-          asset_name: datastax-mgmtapi-shim-3.x.jar
-          asset_content_type: text/html
- 
-
-      - name: Upload Common
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.get_release_url.outputs.URL }}
-          asset_path: management-api-common/target/datastax-mgmtapi-common-*.jar
-          asset_name: datastax-mgmtapi-common.jar
+          asset_path: jars.zip
+          asset_name: jars.zip
           asset_content_type: text/html

--- a/.github/workflows/jar-release.yaml
+++ b/.github/workflows/jar-release.yaml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - uses: actions/checkout@master
       - name: Setup Java JDK
         uses: actions/setup-java@v1.3.0
         with:

--- a/.github/workflows/jar-release.yaml
+++ b/.github/workflows/jar-release.yaml
@@ -1,0 +1,105 @@
+name: Release
+
+on:
+  push:
+    branches: 
+      - release-jar
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  create-release:
+    name: create release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Copy release URL into file
+        run: |
+          mkdir release
+          printf "%s" "${{ steps.create_release.outputs.upload_url }}" > release/url.txt
+      - name: Stash file containing the release URL as an artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: release-url
+          path: ./release
+ 
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v1.3.0
+        with:
+          java-version: 13
+          java-package: jdk
+      - name: Build with Maven
+        run: mvn -q -ff package -DskipTests
+
+      - name: Retrieve stashed release URL
+        uses: actions/download-artifact@v1
+        with:
+          name: release-url
+      - name: Read release URL
+        id: get_release_url
+        run: echo ::set-output name=URL::$(cat release-url/url.txt)
+
+      - name: Upload Agent
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release_url.outputs.URL }}
+          asset_path: management-api-agent/target/datastax-mgmtapi-agent-*.jar
+          asset_name: datastax-mgmtapi-agent.jar
+          asset_content_type: text/html
+
+      - name: Upload API Server
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release_url.outputs.URL }}
+          asset_path: management-api-server/target/datastax-mgmtapi-server-*.jar
+          asset_name: datastax-api-server.jar
+          asset_content_type: text/html
+
+      - name: Upload 4.x Shim 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release_url.outputs.URL }}
+          asset_path: management-api-shim-4.x/target/datastax-mgmtapi-shim-4.x-*-SNAPSHOT.jar
+          asset_name: datastax-mgmtapi-shim-4.x.jar
+          asset_content_type: text/html
+
+      - name: Upload 3.x Shim
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release_url.outputs.URL }}
+          asset_path: management-api-shim-3.x/target/datastax-mgmtapi-shim-3.x-*.jar
+          asset_name: datastax-mgmtapi-shim-3.x.jar
+          asset_content_type: text/html
+ 
+
+      - name: Upload Common
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release_url.outputs.URL }}
+          asset_path: management-api-common/target/datastax-mgmtapi-common-*.jar
+          asset_name: datastax-mgmtapi-common.jar
+          asset_content_type: text/html

--- a/.github/workflows/jar-release.yaml
+++ b/.github/workflows/jar-release.yaml
@@ -34,10 +34,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-<<<<<<< HEAD
 
-=======
->>>>>>> aec1d86c2769d489781395847057e01002f1c855
       - uses: actions/checkout@master
       - name: Setup Java JDK
         uses: actions/setup-java@v1.3.0

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@
   The latest releases are on Docker Hub:
      [Management API for Apache Cassandra 3.11.6](https://hub.docker.com/repository/docker/datastax/cassandra-mgmtapi-3_11_6) and 
      [Management API for Apache Cassandra 4.0 alpha3](https://hub.docker.com/repository/docker/datastax/cassandra-mgmtapi-4_0_0). 
+ 
+  For running standalone the jars can be downloaded from the github release:
+     [Management API Releases Zip](https://github.com/datastax/management-api-for-apache-cassandra/releases)
 
   The Management API can be run as a standalone service or along with the kubernetes 
   [cass-operator](https://github.com/datastax/cass-operator). 


### PR DESCRIPTION
Although users are most likely to use the management API via docker or k8s, if someone wants to use it with Cassandra standalone we should provide the jars in our github releases.

This PR includes the actions workflow that creates releases based on tags and uploads the jars to the release as `jars.zip`.