### PR TITLE
Experimental arm64 support for Cassandra 3.11.6 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,11 +18,6 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - name: Setup Buildx
-        id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v3
-        with:
-          version: latest
       - name: Build Management API in docker
         run: |
           cat <<EOF > ~/.m2/settings.xml
@@ -44,11 +39,7 @@ jobs:
           cp ~/.m2/settings.xml settings.xml
           docker build -t management-api-for-dse-builder -f ./Dockerfile-build-dse ./
           docker tag management-api-for-dse-builder management-api-for-apache-cassandra-builder
-          docker buildx build --load \
-            --tag mgmtapi-3_11 \
-            --file Dockerfile-oss \
-            --target oss311 \
-            --platform linux/amd64 .
+          docker build -t mgmtapi-3_11 -f Dockerfile-3_11 .
           docker build -t mgmtapi-4_0 -f Dockerfile-4_0 .
           docker build -t mgmtapi-dse-68 -f Dockerfile-dse-68 .
       - name: Build with Maven

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,11 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
+      - name: Setup Buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v3
+        with:
+          version: latest
       - name: Build Management API in docker
         run: |
           cat <<EOF > ~/.m2/settings.xml
@@ -39,7 +44,11 @@ jobs:
           cp ~/.m2/settings.xml settings.xml
           docker build -t management-api-for-dse-builder -f ./Dockerfile-build-dse ./
           docker tag management-api-for-dse-builder management-api-for-apache-cassandra-builder
-          docker build -t mgmtapi-3_11 -f Dockerfile-3_11 .
+          docker buildx build --load \
+            --tag mgmtapi-3_11 \
+            --file Dockerfile-oss \
+            --target oss311 \
+            --platform linux/amd64 .
           docker build -t mgmtapi-4_0 -f Dockerfile-4_0 .
           docker build -t mgmtapi-dse-68 -f Dockerfile-dse-68 .
       - name: Build with Maven

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,11 +44,11 @@ jobs:
           cp ~/.m2/settings.xml settings.xml
           docker build -t management-api-for-dse-builder -f ./Dockerfile-build-dse ./
           docker tag management-api-for-dse-builder management-api-for-apache-cassandra-builder
-          docker buildx build --load \
+          docker buildx build \
             --tag mgmtapi-3_11 \
             --file Dockerfile-oss \
             --target oss311 \
-            --platform linux/amd64 .
+            --platform linux/amd64,linux/arm64 .
           docker build -t mgmtapi-4_0 -f Dockerfile-4_0 .
           docker build -t mgmtapi-dse-68 -f Dockerfile-dse-68 .
       - name: Build with Maven

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -5,7 +5,7 @@ on:
     # tags:
     #   - 'v*.*.*'
     branches:
-      - cassandra-mgmtapi-multiarch-2
+      - cassandra-mgmtapi-multiarch-3
 
 jobs:
   # build-dse:

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -44,7 +44,7 @@ jobs:
   #         dockerfile: Dockerfile-dse-68
   build-oss:
     runs-on: ubuntu-latest
-    stes:
+    steps:
       - uses: actions/checkout@master
       - name: Setup Buildx
         id: buildx

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -2,46 +2,52 @@ name: Docker Release
 
 on:
   push:
-    # tags:
-    #   - 'v*.*.*'
-    branches:
-      - cassandra-mgmtapi-multiarch-3
+    tags:
+      - 'v*.*.*'
 
 jobs:
-  # build-dse:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@master
-  #     - name: Build Management API in docker
-  #       run: |
-  #         mkdir -p ~/.m2
-  #         cat <<EOF > ~/.m2/settings.xml
-  #         <settings>
-  #           <servers>
-  #             <server>
-  #               <id>artifactory-snapshots</id>
-  #               <username>${{ secrets.ARTIFACTORY_USERNAME }}</username>
-  #               <password>${{ secrets.ARTIFACTORY_PASSWORD }}</password>
-  #             </server>
-  #             <server>
-  #               <id>artifactory-releases</id>
-  #               <username>${{ secrets.ARTIFACTORY_USERNAME }}</username>
-  #               <password>${{ secrets.ARTIFACTORY_PASSWORD }}</password>
-  #            </server>
-  #          </servers>
-  #         </settings>
-  #         EOF
-  #         cp ~/.m2/settings.xml settings.xml
-  #         docker build -t management-api-for-dse-builder -f ./Dockerfile-build-dse ./
-  #         docker tag management-api-for-dse-builder management-api-for-apache-cassandra-builder
-  #     - name: Publish DSE 6.8 to Registry
-  #       uses: elgohr/Publish-Docker-Github-Action@master
-  #       with:
-  #         name: datastax/dse-mgmtapi-6_8
-  #         username: ${{ secrets.DOCKER_USERNAME }}
-  #         password: ${{ secrets.DOCKER_PASSWORD }}
-  #         tag_names: true
-  #         dockerfile: Dockerfile-dse-68
+  build-dse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Build Management API in docker
+        run: |
+          mkdir -p ~/.m2
+          cat <<EOF > ~/.m2/settings.xml
+          <settings>
+            <servers>
+              <server>
+                <id>artifactory-snapshots</id>
+                <username>${{ secrets.ARTIFACTORY_USERNAME }}</username>
+                <password>${{ secrets.ARTIFACTORY_PASSWORD }}</password>
+              </server>
+              <server>
+                <id>artifactory-releases</id>
+                <username>${{ secrets.ARTIFACTORY_USERNAME }}</username>
+                <password>${{ secrets.ARTIFACTORY_PASSWORD }}</password>
+             </server>
+           </servers>
+          </settings>
+          EOF
+          cp ~/.m2/settings.xml settings.xml
+          docker build -t management-api-for-dse-builder -f ./Dockerfile-build-dse ./
+          docker tag management-api-for-dse-builder management-api-for-apache-cassandra-builder
+      - name: Publish DSE 6.8 to Registry
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: datastax/dse-mgmtapi-6_8
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          tag_names: true
+          dockerfile: Dockerfile-dse-68
+      - name: Publish 4.0 to Registry
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: datastax/cassandra-mgmtapi-4_0_0
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          tag_names: true
+          dockerfile: Dockerfile-4_0
   build-oss:
     runs-on: ubuntu-latest
     steps:
@@ -55,18 +61,9 @@ jobs:
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
       - name: Publish 3.11 to Registry
         run: |
-          # RELEASE_VERSION="${GITHUB_REF##*/}"
-          RELEASE_VERSION="latest"
+          RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
-            --tag johntrimble/cassandra-mgmtapi-multiarch:$RELEASE_VERSION \
+            --tag datastax/cassandra-mgmtapi-3_11_6:$RELEASE_VERSION \
             --file Dockerfile-oss \
             --target oss311 \
             --platform linux/amd64,linux/arm64 .
-      # - name: Publish 4.0 to Registry
-      #   run: |
-      #     RELEASE_VERSION="${GITHUB_REF##*/}"
-      #     docker buildx build --push \
-      #       --tag johntrimble/cassandra-mgmtapi-multiarch:$RELEASE_VERSION \
-      #       --file Dockerfile-oss \
-      #       --target oss40
-      #       --platform linux/amd64,linux/arm64 .

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -2,57 +2,71 @@ name: Docker Release
 
 on:
   push:
-    tags:
-      - 'v*.*.*'
+    # tags:
+    #   - 'v*.*.*'
+    branches:
+      - cassandra-mgmtapi-multiarch-2
 
 jobs:
-  build:
+  # build-dse:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@master
+  #     - name: Build Management API in docker
+  #       run: |
+  #         mkdir -p ~/.m2
+  #         cat <<EOF > ~/.m2/settings.xml
+  #         <settings>
+  #           <servers>
+  #             <server>
+  #               <id>artifactory-snapshots</id>
+  #               <username>${{ secrets.ARTIFACTORY_USERNAME }}</username>
+  #               <password>${{ secrets.ARTIFACTORY_PASSWORD }}</password>
+  #             </server>
+  #             <server>
+  #               <id>artifactory-releases</id>
+  #               <username>${{ secrets.ARTIFACTORY_USERNAME }}</username>
+  #               <password>${{ secrets.ARTIFACTORY_PASSWORD }}</password>
+  #            </server>
+  #          </servers>
+  #         </settings>
+  #         EOF
+  #         cp ~/.m2/settings.xml settings.xml
+  #         docker build -t management-api-for-dse-builder -f ./Dockerfile-build-dse ./
+  #         docker tag management-api-for-dse-builder management-api-for-apache-cassandra-builder
+  #     - name: Publish DSE 6.8 to Registry
+  #       uses: elgohr/Publish-Docker-Github-Action@master
+  #       with:
+  #         name: datastax/dse-mgmtapi-6_8
+  #         username: ${{ secrets.DOCKER_USERNAME }}
+  #         password: ${{ secrets.DOCKER_PASSWORD }}
+  #         tag_names: true
+  #         dockerfile: Dockerfile-dse-68
+  build-oss:
     runs-on: ubuntu-latest
-    steps:
+    stes:
       - uses: actions/checkout@master
-      - name: Build Management API in docker
-        run: |
-          mkdir -p ~/.m2
-          cat <<EOF > ~/.m2/settings.xml
-          <settings>
-            <servers>
-              <server>
-                <id>artifactory-snapshots</id>
-                <username>${{ secrets.ARTIFACTORY_USERNAME }}</username>
-                <password>${{ secrets.ARTIFACTORY_PASSWORD }}</password>
-              </server>
-              <server>
-                <id>artifactory-releases</id>
-                <username>${{ secrets.ARTIFACTORY_USERNAME }}</username>
-                <password>${{ secrets.ARTIFACTORY_PASSWORD }}</password>
-             </server>
-           </servers>
-          </settings>
-          EOF
-          cp ~/.m2/settings.xml settings.xml
-          docker build -t management-api-for-dse-builder -f ./Dockerfile-build-dse ./
-          docker tag management-api-for-dse-builder management-api-for-apache-cassandra-builder
+      - name: Setup Buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v3
+        with:
+          version: latest
+      - name: Login to Docker Hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
       - name: Publish 3.11 to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
-        with:
-          name: datastax/cassandra-mgmtapi-3_11_6
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          tag_names: true
-          dockerfile: Dockerfile-3_11
-      - name: Publish 4.0 to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
-        with:
-          name: datastax/cassandra-mgmtapi-4_0_0
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          tag_names: true
-          dockerfile: Dockerfile-4_0
-      - name: Publish DSE 6.8 to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
-        with:
-          name: datastax/dse-mgmtapi-6_8
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          tag_names: true
-          dockerfile: Dockerfile-dse-68
+        run: |
+          # RELEASE_VERSION="${GITHUB_REF##*/}"
+          RELEASE_VERSION="latest"
+          docker buildx build --push \
+            --tag johntrimble/cassandra-mgmtapi-multiarch:$RELEASE_VERSION \
+            --file Dockerfile-oss \
+            --target oss311 \
+            --platform linux/amd64,linux/arm64 .
+      # - name: Publish 4.0 to Registry
+      #   run: |
+      #     RELEASE_VERSION="${GITHUB_REF##*/}"
+      #     docker buildx build --push \
+      #       --tag johntrimble/cassandra-mgmtapi-multiarch:$RELEASE_VERSION \
+      #       --file Dockerfile-oss \
+      #       --target oss40
+      #       --platform linux/amd64,linux/arm64 .

--- a/Dockerfile-oss
+++ b/Dockerfile-oss
@@ -20,15 +20,18 @@ COPY management-api-shim-4.x ./management-api-shim-4.x
 RUN mvn -q -ff package -DskipTests
 
 FROM --platform=$BUILDPLATFORM maven:3.6.3-jdk-8-slim as netty4150
-RUN mvn dependency:get -DgroupId=io.netty -DartifactId=netty-all -Dversion=4.1.50.Final -Dtransitive=false
+RUN mvn dependency:get -DgroupId=io.netty -DartifactId=netty-transport-native-epoll -Dversion=4.1.50.Final -Dclassifier=linux-aarch64
+# RUN mvn dependency:get -DgroupId=io.netty -DartifactId=netty-all -Dversion=4.1.50.Final -Dtransitive=false
 
 FROM --platform=linux/amd64 cassandra:3.11 as oss311-amd64
 
 FROM --platform=linux/arm64 cassandra:3.11 as oss311-arm64
-# Netty arm64 epoll support was not added until 4.1.50 (https://github.com/netty/netty/pull/9804)
-# Only replace this dependency for arm64 to avoid regressions
-RUN rm /opt/cassandra/lib/netty-all-*.jar
-COPY --from=netty4150 /root/.m2/repository/io/netty/netty-all/4.1.50.Final/netty-all-4.1.50.Final.jar /opt/cassandra/lib/netty-all-4.1.50.Final.jar
+# The management api agent uses epoll, but Netty did not include arm64 binaries
+# until version 4.1.50 (https://github.com/netty/netty/pull/9804)
+# Only add this dependency for arm64 to avoid regressions
+COPY --from=netty4150 /root/.m2/repository/io/netty/netty-transport-native-epoll/4.1.50.Final/netty-transport-native-epoll-4.1.50.Final-linux-aarch64.jar /opt/cassandra/lib/
+# RUN rm /opt/cassandra/lib/netty-all-*.jar
+# COPY --from=netty4150 /root/.m2/repository/io/netty/netty-all/4.1.50.Final/netty-all-4.1.50.Final.jar /opt/cassandra/lib/netty-all-4.1.50.Final.jar
 
 FROM oss311-${TARGETARCH} as oss311
 
@@ -72,8 +75,9 @@ FROM --platform=linux/amd64 cassandra:4.0 as oss40-amd64
 FROM --platform=linux/arm64 cassandra:4.0 as oss40-arm64
 # Netty arm64 epoll support was not added until 4.1.50 (https://github.com/netty/netty/pull/9804)
 # Only replace this dependency for arm64 to avoid regressions
-RUN rm /opt/cassandra/lib/netty-all-*.jar
-COPY --from=netty4150 /root/.m2/repository/io/netty/netty-all/4.1.50.Final/netty-all-4.1.50.Final.jar /opt/cassandra/lib/netty-all-4.1.50.Final.jar
+# RUN rm /opt/cassandra/lib/netty-all-*.jar
+COPY --from=netty4150 /root/.m2/repository/io/netty/netty-transport-native-epoll/4.1.50.Final/netty-transport-native-epoll-4.1.50.Final-linux-aarch64.jar /opt/cassandra/lib/
+# COPY --from=netty4150 /root/.m2/repository/io/netty/netty-all/4.1.50.Final/netty-all-4.1.50.Final.jar /opt/cassandra/lib/netty-all-4.1.50.Final.jar
 
 FROM oss40-${TARGETARCH} as oss40
 

--- a/Dockerfile-oss
+++ b/Dockerfile-oss
@@ -1,0 +1,110 @@
+FROM --platform=$BUILDPLATFORM maven:3.6.3-jdk-8-slim as builder
+
+WORKDIR /build
+
+COPY pom.xml ./
+COPY management-api-agent/pom.xml ./management-api-agent/pom.xml
+COPY management-api-common/pom.xml ./management-api-common/pom.xml
+COPY management-api-server/pom.xml ./management-api-server/pom.xml
+COPY management-api-shim-3.x/pom.xml ./management-api-shim-3.x/pom.xml
+COPY management-api-shim-4.x/pom.xml ./management-api-shim-4.x/pom.xml
+# this duplicates work done in the next steps, but this should provide
+# a solid cache layer that only gets reset on pom.xml changes
+RUN mvn -q -ff -T 1C install && rm -rf target
+
+COPY management-api-agent ./management-api-agent
+COPY management-api-common ./management-api-common
+COPY management-api-server ./management-api-server
+COPY management-api-shim-3.x ./management-api-shim-3.x
+COPY management-api-shim-4.x ./management-api-shim-4.x
+RUN mvn -q -ff package -DskipTests
+
+FROM --platform=$BUILDPLATFORM maven:3.6.3-jdk-8-slim as netty4150
+RUN mvn dependency:get -DgroupId=io.netty -DartifactId=netty-all -Dversion=4.1.50.Final -Dtransitive=false
+
+FROM --platform=linux/amd64 cassandra:3.11 as oss311-amd64
+
+FROM --platform=linux/arm64 cassandra:3.11 as oss311-arm64
+# Netty arm64 epoll support was not added until 4.1.50 (https://github.com/netty/netty/pull/9804)
+# Only replace this dependency for arm64 to avoid regressions
+RUN rm /opt/cassandra/lib/netty-all-*.jar
+COPY --from=netty4150 /root/.m2/repository/io/netty/netty-all/4.1.50.Final/netty-all-4.1.50.Final.jar /opt/cassandra/lib/netty-all-4.1.50.Final.jar
+
+FROM oss311-${TARGETARCH} as oss311
+
+ARG TARGETARCH
+
+COPY --from=builder /build/management-api-common/target/datastax-mgmtapi-common-0.1.0-SNAPSHOT.jar /etc/cassandra/
+COPY --from=builder /build/management-api-agent/target/datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar /etc/cassandra/
+COPY --from=builder /build/management-api-server/target/datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar /opt/mgmtapi/
+COPY --from=builder /build/management-api-shim-3.x/target/datastax-mgmtapi-shim-3.x-0.1.0-SNAPSHOT.jar /opt/mgmtapi/
+COPY --from=builder /build/management-api-shim-4.x/target/datastax-mgmtapi-shim-4.x-0.1.0-SNAPSHOT.jar /opt/mgmtapi/
+
+ENV TINI_VERSION v0.18.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /tini
+RUN chmod +x /tini
+
+RUN set -eux; \
+  rm -fr /etc/apt/sources.list.d/*; \
+  rm -rf /var/lib/apt/lists/*; \
+  apt-get update; \
+  apt-get install -y --no-install-recommends wget iproute2; \
+  rm -rf /var/lib/apt/lists/*
+
+ENV MCAC_VERSION 0.1.7
+ADD https://github.com/datastax/metric-collector-for-apache-cassandra/releases/download/v${MCAC_VERSION}/datastax-mcac-agent-${MCAC_VERSION}.tar.gz /opt/mcac-agent.tar.gz
+RUN mkdir /opt/mcac-agent && tar zxvf /opt/mcac-agent.tar.gz -C /opt/mcac-agent --strip-components 1 && rm /opt/mcac-agent.tar.gz
+
+# backwards compat with upstream ENTRYPOINT
+COPY scripts/docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh && \
+  ln -sf /usr/local/bin/docker-entrypoint.sh /docker-entrypoint.sh
+
+EXPOSE 9103
+EXPOSE 8080
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["mgmtapi"]
+
+
+FROM --platform=linux/amd64 cassandra:4.0 as oss40-amd64
+
+FROM --platform=linux/arm64 cassandra:4.0 as oss40-arm64
+# Netty arm64 epoll support was not added until 4.1.50 (https://github.com/netty/netty/pull/9804)
+# Only replace this dependency for arm64 to avoid regressions
+RUN rm /opt/cassandra/lib/netty-all-*.jar
+COPY --from=netty4150 /root/.m2/repository/io/netty/netty-all/4.1.50.Final/netty-all-4.1.50.Final.jar /opt/cassandra/lib/netty-all-4.1.50.Final.jar
+
+FROM oss40-${TARGETARCH} as oss40
+
+ARG TARGETARCH
+
+COPY --from=builder /build/management-api-common/target/datastax-mgmtapi-common-0.1.0-SNAPSHOT.jar /etc/cassandra/
+COPY --from=builder /build/management-api-agent/target/datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar /etc/cassandra/
+COPY --from=builder /build/management-api-server/target/datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar /opt/mgmtapi/
+COPY --from=builder /build/management-api-shim-3.x/target/datastax-mgmtapi-shim-3.x-0.1.0-SNAPSHOT.jar /opt/mgmtapi/
+COPY --from=builder /build/management-api-shim-4.x/target/datastax-mgmtapi-shim-4.x-0.1.0-SNAPSHOT.jar /opt/mgmtapi/
+
+ENV TINI_VERSION v0.18.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /tini
+RUN chmod +x /tini
+
+RUN set -eux; \
+  apt-get update; \
+  apt-get install -y --no-install-recommends wget iproute2; \
+  rm -rf /var/lib/apt/lists/*
+
+ENV MCAC_VERSION 0.1.7
+ADD https://github.com/datastax/metric-collector-for-apache-cassandra/releases/download/v${MCAC_VERSION}/datastax-mcac-agent-${MCAC_VERSION}.tar.gz /opt/mcac-agent.tar.gz
+RUN mkdir /opt/mcac-agent && tar zxvf /opt/mcac-agent.tar.gz -C /opt/mcac-agent --strip-components 1 && rm /opt/mcac-agent.tar.gz
+
+# backwards compat with upstream ENTRYPOINT
+COPY scripts/docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh && \
+  ln -sf /usr/local/bin/docker-entrypoint.sh /docker-entrypoint.sh
+
+EXPOSE 9103
+EXPOSE 8080
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["mgmtapi"]

--- a/Dockerfile-oss
+++ b/Dockerfile-oss
@@ -67,44 +67,49 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["mgmtapi"]
 
 
-FROM --platform=linux/amd64 cassandra:4.0 as oss40-amd64
+# NOTE: Presently, OSS doesn't have official Cassandra 4.0 builds on dockerhub
+# and our build at datastax/cassandra:4.0 is not a multiarch image like the
+# official ones. Once one of those issues is fixed, the following targets can
+# be used to build Cassandra 4.0 with Management API.
 
-FROM --platform=linux/arm64 cassandra:4.0 as oss40-arm64
-# Netty arm64 epoll support was not added until 4.1.50 (https://github.com/netty/netty/pull/9804)
-# Only replace this dependency for arm64 to avoid regressions
-RUN rm /opt/cassandra/lib/netty-all-*.jar
-COPY --from=netty4150 /root/.m2/repository/io/netty/netty-all/4.1.50.Final/netty-all-4.1.50.Final.jar /opt/cassandra/lib/netty-all-4.1.50.Final.jar
+# FROM --platform=linux/amd64 cassandra:4.0 as oss40-amd64
 
-FROM oss40-${TARGETARCH} as oss40
+# FROM --platform=linux/arm64 cassandra:4.0 as oss40-arm64
+# # Netty arm64 epoll support was not added until 4.1.50 (https://github.com/netty/netty/pull/9804)
+# # Only replace this dependency for arm64 to avoid regressions
+# RUN rm /opt/cassandra/lib/netty-all-*.jar
+# COPY --from=netty4150 /root/.m2/repository/io/netty/netty-all/4.1.50.Final/netty-all-4.1.50.Final.jar /opt/cassandra/lib/netty-all-4.1.50.Final.jar
 
-ARG TARGETARCH
+# FROM oss40-${TARGETARCH} as oss40
 
-COPY --from=builder /build/management-api-common/target/datastax-mgmtapi-common-0.1.0-SNAPSHOT.jar /etc/cassandra/
-COPY --from=builder /build/management-api-agent/target/datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar /etc/cassandra/
-COPY --from=builder /build/management-api-server/target/datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar /opt/mgmtapi/
-COPY --from=builder /build/management-api-shim-3.x/target/datastax-mgmtapi-shim-3.x-0.1.0-SNAPSHOT.jar /opt/mgmtapi/
-COPY --from=builder /build/management-api-shim-4.x/target/datastax-mgmtapi-shim-4.x-0.1.0-SNAPSHOT.jar /opt/mgmtapi/
+# ARG TARGETARCH
 
-ENV TINI_VERSION v0.18.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /tini
-RUN chmod +x /tini
+# COPY --from=builder /build/management-api-common/target/datastax-mgmtapi-common-0.1.0-SNAPSHOT.jar /etc/cassandra/
+# COPY --from=builder /build/management-api-agent/target/datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar /etc/cassandra/
+# COPY --from=builder /build/management-api-server/target/datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar /opt/mgmtapi/
+# COPY --from=builder /build/management-api-shim-3.x/target/datastax-mgmtapi-shim-3.x-0.1.0-SNAPSHOT.jar /opt/mgmtapi/
+# COPY --from=builder /build/management-api-shim-4.x/target/datastax-mgmtapi-shim-4.x-0.1.0-SNAPSHOT.jar /opt/mgmtapi/
 
-RUN set -eux; \
-  apt-get update; \
-  apt-get install -y --no-install-recommends wget iproute2; \
-  rm -rf /var/lib/apt/lists/*
+# ENV TINI_VERSION v0.18.0
+# ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /tini
+# RUN chmod +x /tini
 
-ENV MCAC_VERSION 0.1.7
-ADD https://github.com/datastax/metric-collector-for-apache-cassandra/releases/download/v${MCAC_VERSION}/datastax-mcac-agent-${MCAC_VERSION}.tar.gz /opt/mcac-agent.tar.gz
-RUN mkdir /opt/mcac-agent && tar zxvf /opt/mcac-agent.tar.gz -C /opt/mcac-agent --strip-components 1 && rm /opt/mcac-agent.tar.gz
+# RUN set -eux; \
+#   apt-get update; \
+#   apt-get install -y --no-install-recommends wget iproute2; \
+#   rm -rf /var/lib/apt/lists/*
 
-# backwards compat with upstream ENTRYPOINT
-COPY scripts/docker-entrypoint.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh && \
-  ln -sf /usr/local/bin/docker-entrypoint.sh /docker-entrypoint.sh
+# ENV MCAC_VERSION 0.1.7
+# ADD https://github.com/datastax/metric-collector-for-apache-cassandra/releases/download/v${MCAC_VERSION}/datastax-mcac-agent-${MCAC_VERSION}.tar.gz /opt/mcac-agent.tar.gz
+# RUN mkdir /opt/mcac-agent && tar zxvf /opt/mcac-agent.tar.gz -C /opt/mcac-agent --strip-components 1 && rm /opt/mcac-agent.tar.gz
 
-EXPOSE 9103
-EXPOSE 8080
+# # backwards compat with upstream ENTRYPOINT
+# COPY scripts/docker-entrypoint.sh /usr/local/bin/
+# RUN chmod +x /usr/local/bin/docker-entrypoint.sh && \
+#   ln -sf /usr/local/bin/docker-entrypoint.sh /docker-entrypoint.sh
 
-ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["mgmtapi"]
+# EXPOSE 9103
+# EXPOSE 8080
+
+# ENTRYPOINT ["/docker-entrypoint.sh"]
+# CMD ["mgmtapi"]

--- a/Dockerfile-oss
+++ b/Dockerfile-oss
@@ -22,9 +22,9 @@ RUN mvn -q -ff package -DskipTests
 FROM --platform=$BUILDPLATFORM maven:3.6.3-jdk-8-slim as netty4150
 RUN mvn dependency:get -DgroupId=io.netty -DartifactId=netty-all -Dversion=4.1.50.Final -Dtransitive=false
 
-FROM --platform=linux/amd64 cassandra:3.11 as oss311-amd64
+FROM --platform=linux/amd64 cassandra:3.11.7 as oss311-amd64
 
-FROM --platform=linux/arm64 cassandra:3.11 as oss311-arm64
+FROM --platform=linux/arm64 cassandra:3.11.7 as oss311-arm64
 # Netty arm64 epoll support was not added until 4.1.50 (https://github.com/netty/netty/pull/9804)
 # Only replace this dependency for arm64 to avoid regressions
 RUN rm /opt/cassandra/lib/netty-all-*.jar

--- a/Dockerfile-oss
+++ b/Dockerfile-oss
@@ -20,18 +20,15 @@ COPY management-api-shim-4.x ./management-api-shim-4.x
 RUN mvn -q -ff package -DskipTests
 
 FROM --platform=$BUILDPLATFORM maven:3.6.3-jdk-8-slim as netty4150
-RUN mvn dependency:get -DgroupId=io.netty -DartifactId=netty-transport-native-epoll -Dversion=4.1.50.Final -Dclassifier=linux-aarch64
-# RUN mvn dependency:get -DgroupId=io.netty -DartifactId=netty-all -Dversion=4.1.50.Final -Dtransitive=false
+RUN mvn dependency:get -DgroupId=io.netty -DartifactId=netty-all -Dversion=4.1.50.Final -Dtransitive=false
 
 FROM --platform=linux/amd64 cassandra:3.11 as oss311-amd64
 
 FROM --platform=linux/arm64 cassandra:3.11 as oss311-arm64
-# The management api agent uses epoll, but Netty did not include arm64 binaries
-# until version 4.1.50 (https://github.com/netty/netty/pull/9804)
-# Only add this dependency for arm64 to avoid regressions
-COPY --from=netty4150 /root/.m2/repository/io/netty/netty-transport-native-epoll/4.1.50.Final/netty-transport-native-epoll-4.1.50.Final-linux-aarch64.jar /opt/cassandra/lib/
-# RUN rm /opt/cassandra/lib/netty-all-*.jar
-# COPY --from=netty4150 /root/.m2/repository/io/netty/netty-all/4.1.50.Final/netty-all-4.1.50.Final.jar /opt/cassandra/lib/netty-all-4.1.50.Final.jar
+# Netty arm64 epoll support was not added until 4.1.50 (https://github.com/netty/netty/pull/9804)
+# Only replace this dependency for arm64 to avoid regressions
+RUN rm /opt/cassandra/lib/netty-all-*.jar
+COPY --from=netty4150 /root/.m2/repository/io/netty/netty-all/4.1.50.Final/netty-all-4.1.50.Final.jar /opt/cassandra/lib/netty-all-4.1.50.Final.jar
 
 FROM oss311-${TARGETARCH} as oss311
 
@@ -75,9 +72,8 @@ FROM --platform=linux/amd64 cassandra:4.0 as oss40-amd64
 FROM --platform=linux/arm64 cassandra:4.0 as oss40-arm64
 # Netty arm64 epoll support was not added until 4.1.50 (https://github.com/netty/netty/pull/9804)
 # Only replace this dependency for arm64 to avoid regressions
-# RUN rm /opt/cassandra/lib/netty-all-*.jar
-COPY --from=netty4150 /root/.m2/repository/io/netty/netty-transport-native-epoll/4.1.50.Final/netty-transport-native-epoll-4.1.50.Final-linux-aarch64.jar /opt/cassandra/lib/
-# COPY --from=netty4150 /root/.m2/repository/io/netty/netty-all/4.1.50.Final/netty-all-4.1.50.Final.jar /opt/cassandra/lib/netty-all-4.1.50.Final.jar
+RUN rm /opt/cassandra/lib/netty-all-*.jar
+COPY --from=netty4150 /root/.m2/repository/io/netty/netty-all/4.1.50.Final/netty-all-4.1.50.Final.jar /opt/cassandra/lib/netty-all-4.1.50.Final.jar
 
 FROM oss40-${TARGETARCH} as oss40
 

--- a/management-api-common/pom.xml
+++ b/management-api-common/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <slf4j.version>1.7.25</slf4j.version>
         <logback.version>1.2.3</logback.version>
-        <netty.version>4.1.45.Final</netty.version>
+        <netty.version>4.1.50.Final</netty.version>
         <cassandra.version>3.11.5</cassandra.version>
     </properties>
 

--- a/management-api-server/pom.xml
+++ b/management-api-server/pom.xml
@@ -27,7 +27,7 @@
         <airline.version>2.7.0</airline.version>
         <jaxrs.version>2.0.8</jaxrs.version>
         <resteasy.version>4.0.0.Final</resteasy.version>
-        <netty.version>4.1.45.Final</netty.version>
+        <netty.version>4.1.50.Final</netty.version>
         <driver.version>4.4.0</driver.version>
         <docker.java.version>3.1.2</docker.java.version>
         <cassandra.version>3.11.5</cassandra.version>

--- a/management-api-server/src/test/java/com/datastax/mgmtapi/BaseDockerIntegrationTest.java
+++ b/management-api-server/src/test/java/com/datastax/mgmtapi/BaseDockerIntegrationTest.java
@@ -81,12 +81,14 @@ public abstract class BaseDockerIntegrationTest
     public static Iterable<String[]> functions()
     {
         List<String[]> l =  Lists.newArrayList(
-                new String[]{"3_11"},
-                new String[]{"4_0"}
+                // new String[]{"3_11"},
+                // new String[]{"4_0"}
         );
 
-        if (Boolean.getBoolean("dseIncluded"))
-            l.add(new String[]{"dse-68"});
+        l.add(new String[]{"3_11"});
+
+        // if (Boolean.getBoolean("dseIncluded"))
+        //     l.add(new String[]{"dse-68"});
 
         return l;
     }

--- a/management-api-server/src/test/java/com/datastax/mgmtapi/BaseDockerIntegrationTest.java
+++ b/management-api-server/src/test/java/com/datastax/mgmtapi/BaseDockerIntegrationTest.java
@@ -81,14 +81,12 @@ public abstract class BaseDockerIntegrationTest
     public static Iterable<String[]> functions()
     {
         List<String[]> l =  Lists.newArrayList(
-                // new String[]{"3_11"},
-                // new String[]{"4_0"}
+                new String[]{"3_11"},
+                new String[]{"4_0"}
         );
 
-        l.add(new String[]{"3_11"});
-
-        // if (Boolean.getBoolean("dseIncluded"))
-        //     l.add(new String[]{"dse-68"});
+        if (Boolean.getBoolean("dseIncluded"))
+            l.add(new String[]{"dse-68"});
 
         return l;
     }

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -40,6 +40,11 @@ _sed-in-place() {
 	rm "$tempFile"
 }
 
+_metrics_collector_supported() {
+	# currently, metrics collector does not work on arm64
+	[ "$(uname -m)" != "aarch64" ]
+}
+
 if [ "$1" = 'mgmtapi' ]; then
 	echo "Starting Management API"
 
@@ -55,7 +60,7 @@ if [ "$1" = 'mgmtapi' ]; then
 	# 2. We don't wan't operator or configbuilder to care so much about the version number or
 	#    the fact this jar even exists.
 	
-	if ! grep -qxF "JVM_OPTS=\"\$JVM_OPTS -javaagent:/opt/mcac-agent/lib/datastax-mcac-agent.jar\"" < /etc/cassandra/cassandra-env.sh ; then
+	if _metrics_collector_supported && ! grep -qxF "JVM_OPTS=\"\$JVM_OPTS -javaagent:/opt/mcac-agent/lib/datastax-mcac-agent.jar\"" < /etc/cassandra/cassandra-env.sh ; then
     # ensure newline at end of file
 		echo "" >> /etc/cassandra/cassandra-env.sh
     echo "JVM_OPTS=\"\$JVM_OPTS -javaagent:/opt/mcac-agent/lib/datastax-mcac-agent.jar\"" >> /etc/cassandra/cassandra-env.sh


### PR DESCRIPTION
Turns the Cassandra 3.11.6 w/ Management API built into a multiarch build supporting both arm64 and amd64. Currently, disables metrics collector on arm64 as our collectd fork does not presently support arm64.

Closes #35 