### PR TITLE
Do not copy jars to /etc/cassandra to avoid being shadowed by volume mounts

### DIFF
--- a/Dockerfile-3_11
+++ b/Dockerfile-3_11
@@ -2,8 +2,8 @@ FROM management-api-for-apache-cassandra-builder as builder
 
 FROM cassandra:3.11.7
 
-COPY --from=builder /build/management-api-common/target/datastax-mgmtapi-common-0.1.0-SNAPSHOT.jar /etc/cassandra/
-COPY --from=builder /build/management-api-agent/target/datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar /etc/cassandra/
+COPY --from=builder /build/management-api-common/target/datastax-mgmtapi-common-0.1.0-SNAPSHOT.jar /tmp
+COPY --from=builder /build/management-api-agent/target/datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar /tmp
 COPY --from=builder /build/management-api-server/target/datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar /opt/mgmtapi/
 COPY --from=builder /build/management-api-shim-3.x/target/datastax-mgmtapi-shim-3.x-0.1.0-SNAPSHOT.jar /opt/mgmtapi/
 COPY --from=builder /build/management-api-shim-4.x/target/datastax-mgmtapi-shim-4.x-0.1.0-SNAPSHOT.jar /opt/mgmtapi/

--- a/Dockerfile-4_0
+++ b/Dockerfile-4_0
@@ -2,8 +2,8 @@ FROM management-api-for-apache-cassandra-builder as builder
 
 FROM datastax/cassandra:4.0
 
-COPY --from=builder /build/management-api-common/target/datastax-mgmtapi-common-0.1.0-SNAPSHOT.jar /etc/cassandra/
-COPY --from=builder /build/management-api-agent/target/datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar /etc/cassandra/
+COPY --from=builder /build/management-api-common/target/datastax-mgmtapi-common-0.1.0-SNAPSHOT.jar /tmp
+COPY --from=builder /build/management-api-agent/target/datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar /tmp
 COPY --from=builder /build/management-api-server/target/datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar /opt/mgmtapi/
 COPY --from=builder /build/management-api-shim-3.x/target/datastax-mgmtapi-shim-3.x-0.1.0-SNAPSHOT.jar /opt/mgmtapi/
 COPY --from=builder /build/management-api-shim-4.x/target/datastax-mgmtapi-shim-4.x-0.1.0-SNAPSHOT.jar /opt/mgmtapi/

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -177,6 +177,9 @@ if [ "$1" = 'mgmtapi' ]; then
 		MGMT_API_ARGS="$MGMT_API_ARGS $MGMT_API_NO_KEEP_ALIVE"
 	fi
 
+	cp /tmp/datastax-mgmtapi-common-0.1.0-SNAPSHOT.jar /etc/cassandra
+	cp /tmp/datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar /etc/cassandra
+
 	MGMT_API_JAR="$(find "/opt/mgmtapi" -name *server*.jar)"
 
 	echo "Running" java ${MGMT_API_JAVA_OPTS} -Xms128m -Xmx128m -jar "$MGMT_API_JAR" $MGMT_API_ARGS


### PR DESCRIPTION
This is for #50.