### PR TITLE
Add snapshot management

### DIFF
--- a/management-api-server/doc/openapi.json
+++ b/management-api-server/doc/openapi.json
@@ -509,6 +509,91 @@
         }
       }
     },
+    "/api/v0/ops/node/snapshots" : {
+      "get" : {
+        "summary" : "Retrieve snapshot details",
+        "operationId" : "getSnapshotDetails",
+        "parameters" : [ {
+          "name" : "snapshotNames",
+          "in" : "query",
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "keyspaces",
+          "in" : "query",
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "application/json" : { }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "summary" : "Clear snapshots",
+        "operationId" : "clearSnapshots",
+        "parameters" : [ {
+          "name" : "snapshotNames",
+          "in" : "query",
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "keyspaces",
+          "in" : "query",
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "text/plain" : { }
+            }
+          }
+        }
+      },
+      "post" : {
+        "summary" : "Take a snapshot",
+        "operationId" : "takeSnapshot",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/TakeSnapshotRequest"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "text/plain" : { }
+            }
+          }
+        }
+      }
+    },
     "/api/v0/ops/tables/sstables/upgrade" : {
       "post" : {
         "summary" : "Rewrite sstables (for the requested tables) that are not on the current version (thus upgrading them to said current version)",
@@ -745,6 +830,33 @@
             }
           },
           "tables" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }
+      },
+      "TakeSnapshotRequest" : {
+        "required" : [ ],
+        "type" : "object",
+        "properties" : {
+          "snapshot_name" : {
+            "type" : "string"
+          },
+          "keyspaces" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "table_name" : {
+            "type" : "string"
+          },
+          "skip_flush" : {
+            "type" : "boolean"
+          },
+          "keyspace_tables" : {
             "type" : "array",
             "items" : {
               "type" : "string"

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/models/TakeSnapshotRequest.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/models/TakeSnapshotRequest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+package com.datastax.mgmtapi.resources.models;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class TakeSnapshotRequest implements Serializable {
+
+    @JsonProperty(value = "snapshot_name", required = false)
+    public final String snapshotName;
+
+    @JsonProperty(value = "keyspaces", required = false)
+    public final List<String> keyspaces;
+
+    @JsonProperty(value = "table_name", required = false)
+    public final String tableName;
+
+    @JsonProperty(value = "skip_flush", required = false)
+    public final Boolean skipFlush;
+
+    @JsonProperty(value = "keyspace_tables", required = false)
+    public final List<String> keyspaceTables;
+
+    @JsonCreator
+    public TakeSnapshotRequest(
+            @JsonProperty("snapshot_name") String snapshotName,
+            @JsonProperty("keyspaces") List<String> keyspaces,
+            @JsonProperty("table_name") String tableName,
+            @JsonProperty("skip_flsuh") Boolean skipFlush,
+            @JsonProperty("keyspace_tables") List<String> keyspaceTables)
+    {
+        this.snapshotName = snapshotName == null ? Long.toString(System.currentTimeMillis()) : snapshotName;;
+        this.keyspaces = keyspaces;
+        this.tableName = tableName;
+        this.skipFlush = skipFlush == null ? Boolean.FALSE : skipFlush;
+        this.keyspaceTables = keyspaceTables;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 83 * hash + Objects.hashCode(this.snapshotName);
+        hash = 83 * hash + Objects.hashCode(this.keyspaces);
+        hash = 83 * hash + Objects.hashCode(this.tableName);
+        hash = 83 * hash + Objects.hashCode(this.skipFlush);
+        hash = 83 * hash + Objects.hashCode(this.keyspaceTables);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+        {
+            return true;
+        }
+        if (obj == null)
+        {
+            return false;
+        }
+        if (getClass() != obj.getClass())
+        {
+            return false;
+        }
+        final TakeSnapshotRequest other = (TakeSnapshotRequest) obj;
+        if (!Objects.equals(this.snapshotName, other.snapshotName))
+        {
+            return false;
+        }
+        if (!Objects.equals(this.keyspaces, other.keyspaces))
+        {
+            return false;
+        }
+        if (!Objects.equals(this.tableName, other.tableName))
+        {
+            return false;
+        }
+        if (!Objects.equals(this.skipFlush, other.skipFlush))
+        {
+            return false;
+        }
+        if (!Objects.equals(this.keyspaceTables, other.keyspaceTables))
+        {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/management-api-server/src/test/java/com/datastax/mgmtapi/NonDestructiveOpsIntegrationTest.java
+++ b/management-api-server/src/test/java/com/datastax/mgmtapi/NonDestructiveOpsIntegrationTest.java
@@ -469,38 +469,39 @@ public class NonDestructiveOpsIntegrationTest extends BaseDockerIntegrationTest
         assertTrue(requestSuccessful);
     }
 
-	@Test
-	public void testGetSnapshotDetails() throws IOException, URISyntaxException, InterruptedException
-	{
-		assumeTrue(IntegrationTestUtils.shouldRun());
-		ensureStarted();
+    @Test
+    public void testGetSnapshotDetails() throws IOException, URISyntaxException, InterruptedException
+    {
+        assumeTrue(IntegrationTestUtils.shouldRun());
+        ensureStarted();
 
-		NettyHttpClient client = new NettyHttpClient(BASE_URL);
+        NettyHttpClient client = new NettyHttpClient(BASE_URL);
 
-		URIBuilder uriBuilder = new URIBuilder(BASE_PATH + "/ops/node/snapshots");
-		URI takeSnapshotUri = uriBuilder.build();
+        URIBuilder uriBuilder = new URIBuilder(BASE_PATH + "/ops/node/snapshots");
+        URI takeSnapshotUri = uriBuilder.build();
 
-		// create a snapshot
-		TakeSnapshotRequest takeSnapshotRequest = new TakeSnapshotRequest("testSnapshot",  Arrays.asList("system_schema", "system_traces", "system_distributed"), null, null, null);
-		String requestAsJSON = WriterUtility.asString(takeSnapshotRequest, MediaType.APPLICATION_JSON);
+        // create a snapshot
+        TakeSnapshotRequest takeSnapshotRequest = new TakeSnapshotRequest("testSnapshot",  Arrays.asList("system_schema", "system_traces", "system_distributed"), null, null, null);
+        String requestAsJSON = WriterUtility.asString(takeSnapshotRequest, MediaType.APPLICATION_JSON);
 
-		boolean takeSnapshotSuccessful = client.post(takeSnapshotUri.toURL(), requestAsJSON).thenApply(r -> r.status().code() == HttpStatus.SC_OK).join();
-		assertTrue(takeSnapshotSuccessful);
+        boolean takeSnapshotSuccessful = client.post(takeSnapshotUri.toURL(), requestAsJSON).thenApply(r -> r.status().code() == HttpStatus.SC_OK).join();
+        assertTrue(takeSnapshotSuccessful);
 
-		// get snapshot details
-		URI getSnapshotsUri = uriBuilder.addParameter("snapshotNames", "testSnapshot").build();
-		String getSnapshotResponse = client.get(getSnapshotsUri.toURL())
-				.thenApply(this::responseAsString).join();
-		assertNotNull(getSnapshotResponse);
+        // get snapshot details
+        URI getSnapshotsUri = uriBuilder.addParameter("snapshotNames", "testSnapshot").build();
+        String getSnapshotResponse = client.get(getSnapshotsUri.toURL())
+                .thenApply(this::responseAsString).join();
+        assertNotNull(getSnapshotResponse);
         Object responseObject = ReaderUtility.read(Object.class, MediaType.APPLICATION_JSON, getSnapshotResponse);
         assertTrue(responseObject instanceof Map);
-		Map<Object, Object> responseObj = (Map)responseObject;
+        Map<Object, Object> responseObj = (Map)responseObject;
         assertTrue(responseObj.containsKey("entity"));
         Object entityObj = responseObj.get("entity");
         assertTrue(entityObj instanceof List);
-		List<Object> entities = (List<Object>)entityObj;
-		assertFalse(entities.isEmpty());
-        for (Object entity : entities) {
+        List<Object> entities = (List<Object>)entityObj;
+        assertFalse(entities.isEmpty());
+        for (Object entity : entities)
+        {
             assertTrue(entity instanceof Map);
             Map<String, String> entityMap = (Map<String, String>)entity;
             assertTrue(entityMap.containsKey("Snapshot name"));
@@ -509,23 +510,23 @@ public class NonDestructiveOpsIntegrationTest extends BaseDockerIntegrationTest
         }
 
         // delete snapshot
-		URI clearSnapshotsUri = uriBuilder.addParameter("snapshotNames", "testSnapshot").build();
+        URI clearSnapshotsUri = uriBuilder.addParameter("snapshotNames", "testSnapshot").build();
         boolean clearSnapshotSuccessful = client.delete(clearSnapshotsUri.toURL()).thenApply(r -> r.status().code() == HttpStatus.SC_OK).join();
         assertTrue(clearSnapshotSuccessful);
 
         // verify snapshot deleted
-		getSnapshotResponse = client.get(getSnapshotsUri.toURL())
-				.thenApply(this::responseAsString).join();
-		assertNotNull(getSnapshotResponse);
-		responseObject = ReaderUtility.read(Object.class, MediaType.APPLICATION_JSON, getSnapshotResponse);
-		assertTrue(responseObject instanceof Map);
-		responseObj = (Map)responseObject;
-		assertTrue(responseObj.containsKey("entity"));
-		entityObj = responseObj.get("entity");
-		assertTrue(entityObj instanceof List);
-		entities = (List<Object>)entityObj;
-		assertTrue(entities.isEmpty());
-	}
+        getSnapshotResponse = client.get(getSnapshotsUri.toURL())
+                .thenApply(this::responseAsString).join();
+        assertNotNull(getSnapshotResponse);
+        responseObject = ReaderUtility.read(Object.class, MediaType.APPLICATION_JSON, getSnapshotResponse);
+        assertTrue(responseObject instanceof Map);
+        responseObj = (Map)responseObject;
+        assertTrue(responseObj.containsKey("entity"));
+        entityObj = responseObj.get("entity");
+        assertTrue(entityObj instanceof List);
+        entities = (List<Object>)entityObj;
+        assertTrue(entities.isEmpty());
+    }
 
     private void createKeyspace(NettyHttpClient client, String localDc, String keyspaceName) throws IOException, URISyntaxException
     {

--- a/management-api-server/src/test/java/com/datastax/mgmtapi/helpers/NettyHttpClient.java
+++ b/management-api-server/src/test/java/com/datastax/mgmtapi/helpers/NettyHttpClient.java
@@ -176,10 +176,10 @@ public class NettyHttpClient
         return result;
     }
 
-	public CompletableFuture<FullHttpResponse> delete(URL url)
-	{
-		return buildAndSendRequest(HttpMethod.DELETE, url);
-	}
+    public CompletableFuture<FullHttpResponse> delete(URL url)
+    {
+        return buildAndSendRequest(HttpMethod.DELETE, url);
+    }
 
     /**
      * Common method for building and sending GET or DELETE requests.
@@ -188,18 +188,18 @@ public class NettyHttpClient
      */
     private CompletableFuture<FullHttpResponse> buildAndSendRequest(HttpMethod method, URL url)
     {
-		CompletableFuture<FullHttpResponse> result = new CompletableFuture<>();
+        CompletableFuture<FullHttpResponse> result = new CompletableFuture<>();
 
-		if (!activeRequestFuture.compareAndSet(null, result))
-			throw new RuntimeException("outstanding request");
+        if (!activeRequestFuture.compareAndSet(null, result))
+            throw new RuntimeException("outstanding request");
 
-		// Prepare the HTTP request.
-		HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, method, url.getFile());
-		request.headers().set(HttpHeaderNames.HOST, url.getHost());
+        // Prepare the HTTP request.
+        HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, method, url.getFile());
+        request.headers().set(HttpHeaderNames.HOST, url.getHost());
 
-		// Send the HTTP request.
-		client.writeAndFlush(request);
+        // Send the HTTP request.
+        client.writeAndFlush(request);
 
-		return result;
+        return result;
     }
 }

--- a/management-api-server/src/test/java/com/datastax/mgmtapi/helpers/NettyHttpClient.java
+++ b/management-api-server/src/test/java/com/datastax/mgmtapi/helpers/NettyHttpClient.java
@@ -140,19 +140,7 @@ public class NettyHttpClient
 
     public CompletableFuture<FullHttpResponse> get(URL url)
     {
-        CompletableFuture<FullHttpResponse> result = new CompletableFuture<>();
-
-        if (!activeRequestFuture.compareAndSet(null, result))
-            throw new RuntimeException("outstanding request");
-
-        // Prepare the HTTP request.
-        HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, url.getFile());
-        request.headers().set(HttpHeaderNames.HOST, url.getHost());
-
-        // Send the HTTP request.
-        client.writeAndFlush(request);
-
-        return result;
+        return buildAndSendRequest(HttpMethod.GET, url);
     }
 
     public CompletableFuture<FullHttpResponse> post(URL url, final CharSequence body) throws UnsupportedEncodingException
@@ -186,5 +174,32 @@ public class NettyHttpClient
         client.writeAndFlush(request);
 
         return result;
+    }
+
+	public CompletableFuture<FullHttpResponse> delete(URL url)
+	{
+		return buildAndSendRequest(HttpMethod.DELETE, url);
+	}
+
+    /**
+     * Common method for building and sending GET or DELETE requests.
+     * @param method Request method (either HttpMethod.GET or HttpMethod.DELETE)
+     * @param url URL to send the request
+     */
+    private CompletableFuture<FullHttpResponse> buildAndSendRequest(HttpMethod method, URL url)
+    {
+		CompletableFuture<FullHttpResponse> result = new CompletableFuture<>();
+
+		if (!activeRequestFuture.compareAndSet(null, result))
+			throw new RuntimeException("outstanding request");
+
+		// Prepare the HTTP request.
+		HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, method, url.getFile());
+		request.headers().set(HttpHeaderNames.HOST, url.getHost());
+
+		// Send the HTTP request.
+		client.writeAndFlush(request);
+
+		return result;
     }
 }


### PR DESCRIPTION
This PR adds GET, DELETE, and POST methods for retrieving, clearing and taking snapshots, respectively. This should resolve [issue #52](https://github.com/datastax/management-api-for-apache-cassandra/issues/52)