### PR TITLE
Update jar-release action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,12 @@ jobs:
             --tag mgmtapi-3_11 \
             --file Dockerfile-oss \
             --target oss311 \
-            --platform linux/amd64,linux/arm64 .
+            --platform linux/amd64 .
+          docker buildx build \
+            --tag mgmtapi-3_11 \
+            --file Dockerfile-oss \
+            --target oss311 \
+            --platform linux/arm64 .
           docker build -t mgmtapi-4_0 -f Dockerfile-4_0 .
           docker build -t mgmtapi-dse-68 -f Dockerfile-dse-68 .
       - name: Build with Maven

--- a/.github/workflows/jar-release.yaml
+++ b/.github/workflows/jar-release.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/checkout@master
       - name: Setup Java JDK
-        uses: actions/setup-java@v1.3.0
+        uses: actions/setup-java@v1
         with:
           java-version: 13
           java-package: jdk

--- a/Dockerfile-astra-4_0
+++ b/Dockerfile-astra-4_0
@@ -2,8 +2,8 @@ FROM management-api-for-apache-cassandra-builder as builder
 
 FROM datastax/astra:4.0
 
-COPY --from=builder /build/management-api-common/target/datastax-mgmtapi-common-0.1.0-SNAPSHOT.jar /etc/cassandra/
-COPY --from=builder /build/management-api-agent/target/datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar /etc/cassandra/
+COPY --from=builder /build/management-api-common/target/datastax-mgmtapi-common-0.1.0-SNAPSHOT.jar /tmp/
+COPY --from=builder /build/management-api-agent/target/datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar /tmp/
 COPY --from=builder /build/management-api-server/target/datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar /opt/mgmtapi/
 COPY --from=builder /build/management-api-shim-3.x/target/datastax-mgmtapi-shim-3.x-0.1.0-SNAPSHOT.jar /opt/mgmtapi/
 COPY --from=builder /build/management-api-shim-4.x/target/datastax-mgmtapi-shim-4.x-0.1.0-SNAPSHOT.jar /opt/mgmtapi/

--- a/Dockerfile-oss
+++ b/Dockerfile-oss
@@ -34,8 +34,8 @@ FROM oss311-${TARGETARCH} as oss311
 
 ARG TARGETARCH
 
-COPY --from=builder /build/management-api-common/target/datastax-mgmtapi-common-0.1.0-SNAPSHOT.jar /etc/cassandra/
-COPY --from=builder /build/management-api-agent/target/datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar /etc/cassandra/
+COPY --from=builder /build/management-api-common/target/datastax-mgmtapi-common-0.1.0-SNAPSHOT.jar /tmp/
+COPY --from=builder /build/management-api-agent/target/datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar /tmp/
 COPY --from=builder /build/management-api-server/target/datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar /opt/mgmtapi/
 COPY --from=builder /build/management-api-shim-3.x/target/datastax-mgmtapi-shim-3.x-0.1.0-SNAPSHOT.jar /opt/mgmtapi/
 COPY --from=builder /build/management-api-shim-4.x/target/datastax-mgmtapi-shim-4.x-0.1.0-SNAPSHOT.jar /opt/mgmtapi/


### PR DESCRIPTION
This PR actually addresses two small issues:

- The jar-release action uses `setup-java`, but uses an old version (v1.3.0) that uses `set-env` and `set-path`, which are not allowed any more. This PR updates to <v1> which is what is used in other actions and is actually the latest
- In merging #51, I missed the fact that `Dockerfile-astra-4_0` and `Dockerfile-oss` also needed similar changes