### PR TITLE
Update buildx ghaction

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,9 +18,11 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
       - name: Setup Buildx
         id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v3
+        uses: docker/setup-buildx-action@v1
         with:
           version: latest
       - name: Build Management API in docker
@@ -48,12 +50,7 @@ jobs:
             --tag mgmtapi-3_11 \
             --file Dockerfile-oss \
             --target oss311 \
-            --platform linux/amd64 .
-          docker buildx build \
-            --tag mgmtapi-3_11 \
-            --file Dockerfile-oss \
-            --target oss311 \
-            --platform linux/arm64 .
+            --platform linux/amd64,linux/arm64 .
           docker build -t mgmtapi-4_0 -f Dockerfile-4_0 .
           docker build -t mgmtapi-dse-68 -f Dockerfile-dse-68 .
       - name: Build with Maven

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -52,9 +52,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
       - name: Setup Buildx
         id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v3
+        uses: docker/setup-buildx-action@v1
         with:
           version: latest
       - name: Login to Docker Hub


### PR DESCRIPTION
This restores the ability to run the multi-platform docker buildx command with both `linux/amd64` and `linux/arm64` platform targets.