### PR TITLE
Add Docker image generation for newer Cassandra versions

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -61,11 +61,30 @@ jobs:
           version: latest
       - name: Login to Docker Hub
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
-      - name: Publish 3.11 to Registry
+      - name: Publish 3.11.7 to Registry
         run: |
           RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
+            --build-arg CASSANDRA_VERSION=3.11.7
             --tag datastax/cassandra-mgmtapi-3_11_7:$RELEASE_VERSION \
+            --file Dockerfile-oss \
+            --target oss311 \
+            --platform linux/amd64,linux/arm64 .
+      - name: Publish 3.11.8 to Registry
+        run: |
+          RELEASE_VERSION="${GITHUB_REF##*/}"
+          docker buildx build --push \
+            --build-arg CASSANDRA_VERSION=3.11.8
+            --tag datastax/cassandra-mgmtapi-3_11_8:$RELEASE_VERSION \
+            --file Dockerfile-oss \
+            --target oss311 \
+            --platform linux/amd64,linux/arm64 .
+      - name: Publish 3.11.9 to Registry
+        run: |
+          RELEASE_VERSION="${GITHUB_REF##*/}"
+          docker buildx build --push \
+            --build-arg CASSANDRA_VERSION=3.11.9
+            --tag datastax/cassandra-mgmtapi-3_11_9:$RELEASE_VERSION \
             --file Dockerfile-oss \
             --target oss311 \
             --platform linux/amd64,linux/arm64 .

--- a/Dockerfile-oss
+++ b/Dockerfile-oss
@@ -1,3 +1,5 @@
+ARG CASSANDRA_VERSION=3.11.9
+
 FROM --platform=$BUILDPLATFORM maven:3.6.3-jdk-8-slim as builder
 
 WORKDIR /build
@@ -22,9 +24,9 @@ RUN mvn -q -ff package -DskipTests
 FROM --platform=$BUILDPLATFORM maven:3.6.3-jdk-8-slim as netty4150
 RUN mvn dependency:get -DgroupId=io.netty -DartifactId=netty-all -Dversion=4.1.50.Final -Dtransitive=false
 
-FROM --platform=linux/amd64 cassandra:3.11.7 as oss311-amd64
+FROM --platform=linux/amd64 cassandra:${CASSANDRA_VERSION} as oss311-amd64
 
-FROM --platform=linux/arm64 cassandra:3.11.7 as oss311-arm64
+FROM --platform=linux/arm64 cassandra:${CASSANDRA_VERSION} as oss311-arm64
 # Netty arm64 epoll support was not added until 4.1.50 (https://github.com/netty/netty/pull/9804)
 # Only replace this dependency for arm64 to avoid regressions
 RUN rm /opt/cassandra/lib/netty-all-*.jar


### PR DESCRIPTION
This will create and publish Docker images of the Management API based on Cassandra 3.11.7, 3.11.8 and 3.11.9. This should address issues #60 and #61 for now.