### PR TITLE
Resteasy update

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,24 @@ on: [push]
 
 jobs:
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        cassandra-version: [3.11, 4.0, dse]
+        include:
+          - cassandra-version: 3.11
+            run311tests: true
+            run40tests: false
+            runDSEtests: false
+          - cassandra-version: 4.0
+            run311tests: false
+            run40tests: true
+            runDSEtests: false
+          - cassandra-version: dse
+            run311tests: false
+            run40tests: false
+            runDSEtests: true
+
     runs-on: ubuntu-latest
 
     steps:
@@ -25,7 +43,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
         with:
           version: latest
-      - name: Build Management API in docker
+      - name: Build with Maven
         run: |
           cat <<EOF > ~/.m2/settings.xml
           <settings>
@@ -44,16 +62,19 @@ jobs:
           </settings>
           EOF
           cp ~/.m2/settings.xml settings.xml
-          docker build -t management-api-for-dse-builder -f ./Dockerfile-build-dse ./
-          docker tag management-api-for-dse-builder management-api-for-apache-cassandra-builder
-          docker buildx build \
-            --tag mgmtapi-3_11 \
-            --file Dockerfile-oss \
-            --target oss311 \
-            --platform linux/amd64,linux/arm64 .
-          docker build -t mgmtapi-4_0 -f Dockerfile-4_0 .
-          docker build -t mgmtapi-dse-68 -f Dockerfile-dse-68 .
-      - name: Build with Maven
-        run: mvn -B -q package -DskipTests --file pom.xml -P dse
-      - name: run tests
-        run: mvn -B -q test --file pom.xml -P dse
+          set -e
+          if [[ "${{ matrix.runDSEtests }}" == "true" ]]
+          then
+            mvn -B -q package -DskipTests --file pom.xml -P dse
+          else
+            mvn -B -q package -DskipTests --file pom.xml
+          fi
+      - name: Run Integration Tests
+        run: |
+          set -e
+          if [[ "${{ matrix.runDSEtests }}" == "true" ]]
+          then
+            mvn -B -q integration-test --file pom.xml -P dse -DrunDSEtests=true
+          else
+            mvn -B -q integration-test --file pom.xml -Drun311tests=${{ matrix.run311tests }} -Drun40tests=${{ matrix.run40tests }}
+          fi

--- a/management-api-agent-3.x/pom.xml
+++ b/management-api-agent-3.x/pom.xml
@@ -12,11 +12,12 @@
     <artifactId>datastax-mgmtapi-agent-3.x</artifactId>
 
     <properties>
-        <cassandra.version>3.11.5</cassandra.version>
+        <cassandra.version>3.11.10</cassandra.version>
         <bytebuddy.version>1.10.10</bytebuddy.version>
         <docker.java.version>3.1.5</docker.java.version>
         <driver.version>4.10.0</driver.version>
         <build.version.file>build_version.sh</build.version.file>
+        <junit.version>4.13.1</junit.version>
     </properties>
 
     <profiles>
@@ -66,7 +67,7 @@
                 <dependency>
                     <groupId>junit</groupId>
                     <artifactId>junit</artifactId>
-                    <version>4.11</version>
+                    <version>${junit.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/management-api-agent-4.x/pom.xml
+++ b/management-api-agent-4.x/pom.xml
@@ -17,6 +17,7 @@
         <docker.java.version>3.1.5</docker.java.version>
         <driver.version>4.10.0</driver.version>
         <build.version.file>build_version.sh</build.version.file>
+        <junit.version>4.13.1</junit.version>
     </properties>
 
     <profiles>
@@ -66,7 +67,7 @@
                 <dependency>
                     <groupId>junit</groupId>
                     <artifactId>junit</artifactId>
-                    <version>4.11</version>
+                    <version>${junit.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/management-api-agent-common/pom.xml
+++ b/management-api-agent-common/pom.xml
@@ -12,11 +12,12 @@
     <artifactId>datastax-mgmtapi-agent-common</artifactId>
 
     <properties>
-        <cassandra.version>3.11.5</cassandra.version>
+        <cassandra.version>3.11.10</cassandra.version>
         <bytebuddy.version>1.10.10</bytebuddy.version>
         <docker.java.version>3.1.5</docker.java.version>
         <driver.version>4.10.0</driver.version>
         <build.version.file>build_version.sh</build.version.file>
+        <junit.version>4.13.1</junit.version>
     </properties>
 
     <profiles>
@@ -61,7 +62,7 @@
                 <dependency>
                     <groupId>junit</groupId>
                     <artifactId>junit</artifactId>
-                    <version>4.11</version>
+                    <version>${junit.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/management-api-common/pom.xml
+++ b/management-api-common/pom.xml
@@ -15,7 +15,9 @@
         <slf4j.version>1.7.25</slf4j.version>
         <logback.version>1.2.3</logback.version>
         <netty.version>4.1.50.Final</netty.version>
-        <cassandra.version>3.11.5</cassandra.version>
+        <cassandra.version>3.11.10</cassandra.version>
+        <junit.version>4.13.1</junit.version>
+        <mockito.version>3.5.13</mockito.version>
     </properties>
 
     <dependencies>
@@ -55,13 +57,14 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.2.4</version>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/management-api-server/pom.xml
+++ b/management-api-server/pom.xml
@@ -25,8 +25,8 @@
         <rsapi.version>2.1.1</rsapi.version>
         <guava.version>19.0</guava.version>
         <airline.version>2.7.0</airline.version>
-        <jaxrs.version>2.0.8</jaxrs.version>
-        <resteasy.version>4.0.0.Final</resteasy.version>
+        <jaxrs.version>2.1.6</jaxrs.version>
+        <resteasy.version>4.5.9.Final</resteasy.version>
         <netty.version>4.1.50.Final</netty.version>
         <driver.version>4.10.0</driver.version>
         <cassandra.version>3.11.5</cassandra.version>

--- a/management-api-server/pom.xml
+++ b/management-api-server/pom.xml
@@ -29,8 +29,12 @@
         <resteasy.version>4.0.0.Final</resteasy.version>
         <netty.version>4.1.50.Final</netty.version>
         <driver.version>4.10.0</driver.version>
-        <docker.java.version>3.1.2</docker.java.version>
         <cassandra.version>3.11.5</cassandra.version>
+        <docker.java.version>3.1.1</docker.java.version>
+        <awaitility.version>4.0.3</awaitility.version>
+        <assertj.version>3.17.2</assertj.version>
+        <junit.version>4.13.1</junit.version>
+        <mockito.version>3.5.13</mockito.version>
     </properties>
 
     <dependencies>
@@ -97,7 +101,7 @@
         <dependency>
             <groupId>com.aries</groupId>
             <artifactId>docker-java-shaded</artifactId>
-            <version>3.1.1</version>
+            <version>${docker.java.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -111,19 +115,25 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>3.0.0</version>
+            <version>${awaitility.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.16.1</version>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -175,7 +185,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M3</version>
+                <version>3.0.0-M5</version>
                 <configuration>
                     <systemPropertyVariables>
                         <dseIncluded>${dseIncluded}</dseIncluded>
@@ -189,6 +199,25 @@
                     <threadCount>1</threadCount>
                     <reuseForks>true</reuseForks>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M5</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <dseIncluded>${dseIncluded}</dseIncluded>
+                        <dockerFileRoot>${basedir}/..</dockerFileRoot>
+                    </systemPropertyVariables>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/management-api-server/src/test/java/com/datastax/mgmtapi/BaseDockerIntegrationTest.java
+++ b/management-api-server/src/test/java/com/datastax/mgmtapi/BaseDockerIntegrationTest.java
@@ -78,17 +78,18 @@ public abstract class BaseDockerIntegrationTest
     protected static DockerHelper docker;
 
     @Parameterized.Parameters(name = "{index}: {0}")
-    public static Iterable<String[]> functions()
+    public static List<String> testVersions()
     {
-        List<String[]> l =  Lists.newArrayList(
-                new String[]{"3_11"},
-                new String[]{"4_0"}
-        );
+        List<String> versions = new ArrayList<>(3);
 
-        if (Boolean.getBoolean("dseIncluded"))
-            l.add(new String[]{"dse-68"});
+        if (Boolean.getBoolean("run311tests"))
+            versions.add("3_11");
+        if (Boolean.getBoolean("run40tests"))
+            versions.add("4_0");
+        if (Boolean.getBoolean("runDSEtests"))
+            versions.add("dse-68");
 
-        return l;
+        return versions;
     }
 
     public BaseDockerIntegrationTest(String version) throws IOException

--- a/management-api-server/src/test/java/com/datastax/mgmtapi/DestructiveOpsIT.java
+++ b/management-api-server/src/test/java/com/datastax/mgmtapi/DestructiveOpsIT.java
@@ -28,11 +28,11 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 @RunWith(Parameterized.class)
-public class DestructiveOpsIntegrationTest extends BaseDockerIntegrationTest
+public class DestructiveOpsIT extends BaseDockerIntegrationTest
 {
-    private static final Logger logger = LoggerFactory.getLogger(NonDestructiveOpsIntegrationTest.class);
+    private static final Logger logger = LoggerFactory.getLogger(NonDestructiveOpsIT.class);
 
-    public DestructiveOpsIntegrationTest(String version) throws IOException
+    public DestructiveOpsIT(String version) throws IOException
     {
         super(version);
     }

--- a/management-api-server/src/test/java/com/datastax/mgmtapi/KeepAliveIT.java
+++ b/management-api-server/src/test/java/com/datastax/mgmtapi/KeepAliveIT.java
@@ -29,9 +29,9 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 @RunWith(Parameterized.class)
-public class KeepAliveIntegrationTest extends BaseDockerIntegrationTest
+public class KeepAliveIT extends BaseDockerIntegrationTest
 {
-    public KeepAliveIntegrationTest(String version) throws IOException
+    public KeepAliveIT(String version) throws IOException
     {
         super(version);
     }

--- a/management-api-server/src/test/java/com/datastax/mgmtapi/LifecycleIT.java
+++ b/management-api-server/src/test/java/com/datastax/mgmtapi/LifecycleIT.java
@@ -41,9 +41,9 @@ import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
 @RunWith(Parameterized.class)
-public class IntegrationTest extends BaseDockerIntegrationTest
+public class LifecycleIT extends BaseDockerIntegrationTest
 {
-    public IntegrationTest(String version) throws IOException
+    public LifecycleIT(String version) throws IOException
     {
         super(version);
     }

--- a/management-api-server/src/test/java/com/datastax/mgmtapi/NonDestructiveOpsIT.java
+++ b/management-api-server/src/test/java/com/datastax/mgmtapi/NonDestructiveOpsIT.java
@@ -49,12 +49,12 @@ import static org.junit.Assume.assumeTrue;
  * node once, running all tests, and then stopping rather than a start/stop during each test case.
  */
 @RunWith(Parameterized.class)
-public class NonDestructiveOpsIntegrationTest extends BaseDockerIntegrationTest
+public class NonDestructiveOpsIT extends BaseDockerIntegrationTest
 {
-    private static final Logger logger = LoggerFactory.getLogger(NonDestructiveOpsIntegrationTest.class);
+    private static final Logger logger = LoggerFactory.getLogger(NonDestructiveOpsIT.class);
 
 
-    public NonDestructiveOpsIntegrationTest(String version) throws IOException
+    public NonDestructiveOpsIT(String version) throws IOException
     {
         super(version);
     }


### PR DESCRIPTION
This updates the RestEasy and Swagger libraries to newer versions that pick up version 2.11.1 of the Jackson Datatbind library. This should address the CVEs listed in #83 

This PR also picks up some test speed improvements for CI, but I have left that as a separate commit.